### PR TITLE
Make sure every getIdentity() call returns the same instance.

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -55,6 +55,13 @@ class AuthenticationService implements AuthenticationServiceInterface
     protected $failures = [];
 
     /**
+     * Identity object.
+     *
+     * @var \Phauthentic\Authentication\Identity\IdentityInterface|null
+     */
+    protected $identity;
+
+    /**
      * Result of the last authenticate() call.
      *
      * @var \Phauthentic\Authentication\Authenticator\ResultInterface|null
@@ -115,6 +122,7 @@ class AuthenticationService implements AuthenticationServiceInterface
     public function authenticate(ServerRequestInterface $request): bool
     {
         $this->checkAuthenticators();
+        $this->identity = null;
         $this->successfulAuthenticator = null;
         $this->failures = [];
 
@@ -235,7 +243,11 @@ class AuthenticationService implements AuthenticationServiceInterface
             return $data;
         }
 
-        return $this->buildIdentity($data);
+        if ($this->identity === null) {
+            $this->identity = $this->buildIdentity($data);
+        }
+
+        return $this->identity;
     }
 
     /**

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -385,4 +385,24 @@ class AuthenticationServiceTest extends TestCase
         $result = $service->buildIdentity($data);
         $this->assertSame($identity, $result);
     }
+
+    public function testGetIdentity()
+    {
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            [],
+            ['username' => 'robert', 'password' => 'robert']
+        );
+
+        $authenticators = $this->createAuthenticators();
+        $service = new AuthenticationService($authenticators, new DefaultIdentityFactory);
+
+        $success = $service->authenticate($request);
+        $this->assertTrue($success);
+
+        $identity = $service->getIdentity();
+        $this->assertNotNull($identity);
+
+        $this->assertSame($identity, $service->getIdentity());
+    }
 }


### PR DESCRIPTION
This prevents the identity is rebuilt on every getIdentity()