### PR TITLE
Remove zend/diactores from require-dev and the tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,11 @@
     ],
     "require": {
         "php": "^7.1",
-        "phauthentic/password-hashers": "dev-master",
+        "phauthentic/password-hashers": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "~1.0",
         "psr/http-server-handler": "~1.0",
-        "psr/http-server-middleware": "^1.0",
-        "zendframework/zend-diactoros": "^1.4.0"
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
@@ -22,7 +21,8 @@
         "phpstan/phpstan": "^0.10.3",
         "phpunit/dbunit": "^4.0",
         "phpunit/phpunit": "^7.0",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "zendframework/zend-diactoros": "^1.4.0"
     },
     "suggest": {
         "firebase/php-jwt": "If you want to use the JWT adapter add this dependency",

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -35,12 +35,23 @@ use Phauthentic\Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Phauthentic\Authentication\UrlChecker\DefaultUrlChecker;
 use Phauthentic\Authentication\UrlChecker\UrlCheckerInterface;
 use Phauthentic\PasswordHasher\DefaultPasswordHasher;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequestFactory;
 
+/**
+ * Authentication Service Test
+ */
 class AuthenticationServiceTest extends TestCase
 {
+    /**
+     * Create a new PasswordIdentifier instance
+     *
+     * @return \Phauthentic\Authentication\Identifier\PasswordIdentifier
+     */
     protected function createPasswordIdentifier()
     {
         $resolver = new TestResolver($this->getConnection()->getConnection());
@@ -49,6 +60,11 @@ class AuthenticationServiceTest extends TestCase
         return new PasswordIdentifier($resolver, $passwordHasher);
     }
 
+    /**
+     * Create a new SessionAuthenticator instance
+     *
+     * @return \Phauthentic\Authentication\Authenticator\SessionAuthenticator
+     */
     protected function createSessionAuthenticator(IdentifierInterface $identifier = null, StorageInterface $storage = null)
     {
         if (!$identifier) {
@@ -61,6 +77,11 @@ class AuthenticationServiceTest extends TestCase
         return new SessionAuthenticator($identifier, $storage);
     }
 
+    /**
+     * Create a new FormAuthenticator instance
+     *
+     * @return \Phauthentic\Authentication\Authenticator\FormAuthenticator
+     */
     protected function createFormAuthenticator(IdentifierInterface $identifier = null, UrlCheckerInterface $urlChecker = null)
     {
         if (!$identifier) {
@@ -74,6 +95,13 @@ class AuthenticationServiceTest extends TestCase
         return new FormAuthenticator($identifier, $urlChecker);
     }
 
+    /**
+     * Create Authenticators
+     *
+     * @param \Phauthentic\Authentication\Identifier\IdentifierInterface
+     * @param \Phauthentic\Authentication\Authenticator\Storage\StorageInterface
+     * @return \Phauthentic\Authentication\Authenticator\AuthenticatorCollectionInterface
+     */
     protected function createAuthenticators(IdentifierInterface $identifier = null, StorageInterface $storage = null)
     {
         $authenticators = new AuthenticatorCollection();
@@ -88,15 +116,55 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
+     * Gets a mocked request
+     *
+     * @param string $path Path
+     * @param array $body Parsed body data as array
+     * @param array §server Server environment
+     * @return mixed
+     */
+    protected function getMockRequest($path, $body, $server = [])
+    {
+        $request = $this->getMockBuilder(ServerRequestInterface::class)
+            ->getMock();
+
+        $uri = $this->getMockBuilder(UriInterface::class)
+            ->getMock();
+
+        $uri->expects($this->any())
+            ->method('getPath')
+            ->willReturn($path);
+
+        $uri->expects($this->any())
+            ->method('__toString')
+            ->willReturn('http://localhost' . $path);
+
+        $request->expects($this->any())
+            ->method('getUri')
+            ->willReturn($uri);
+
+        $request->expects($this->any())
+            ->method('getParsedBody')
+            ->willReturn($body);
+
+        if (!empty($server)) {
+            $request->expects($this->any())
+                ->method('getServerParams')
+                ->willReturn($server);
+        }
+
+        return $request;
+    }
+
+    /**
      * testAuthenticate
      *
      * @return void
      */
-    public function testAuthenticate()
+    public function testAuthenticate(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
 
@@ -130,11 +198,10 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testAuthenticateFailure()
+    public function testAuthenticateFailure(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'invalid']
         );
 
@@ -174,10 +241,11 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testAuthenticateStorage()
+    public function testAuthenticateStorage(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath']
+        $request = $this->getMockRequest(
+            '/testpath',
+            []
         );
 
         $storage = $this->createMock(StorageInterface::class);
@@ -221,14 +289,18 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testAuthenticateWithChallenge()
+    public function testAuthenticateWithChallenge(): void
     {
-        $request = ServerRequestFactory::fromGlobals([
-            'SERVER_NAME' => 'example.com',
-            'REQUEST_URI' => '/testpath',
-            'PHP_AUTH_USER' => 'robert',
-            'PHP_AUTH_PW' => 'WRONG'
-        ]);
+        $request = $this->getMockRequest(
+            '/testpath',
+            [],
+            [
+                'SERVER_NAME' => 'example.com',
+                'REQUEST_URI' => '/testpath',
+                'PHP_AUTH_USER' => 'robert',
+                'PHP_AUTH_PW' => 'WRONG'
+            ]
+        );
 
         $identifier = $this->createPasswordIdentifier();
         $authenticators = new AuthenticatorCollection([
@@ -247,13 +319,13 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testPersistAuthenticatedIdentity()
+    public function testPersistAuthenticatedIdentity(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
+
         $response = new Response();
 
         $storage = $this->createMock(StorageInterface::class);
@@ -286,13 +358,13 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testPersistCustomIdentity()
+    public function testPersistCustomIdentity(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
+
         $response = new Response();
 
         $storage = $this->createMock(StorageInterface::class);
@@ -318,11 +390,10 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testClearIdentity()
+    public function testClearIdentity(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
         $response = new Response();
@@ -348,11 +419,10 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testNoAuthenticatorsLoadedException()
+    public function testNoAuthenticatorsLoadedException(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
 
@@ -369,7 +439,7 @@ class AuthenticationServiceTest extends TestCase
      *
      * @return void
      */
-    public function testBuildIdentity()
+    public function testBuildIdentity(): void
     {
         $data = new ArrayObject(['username' => 'robert']);
         $identity = new Identity($data);
@@ -386,11 +456,10 @@ class AuthenticationServiceTest extends TestCase
         $this->assertSame($identity, $result);
     }
 
-    public function testGetIdentity()
+    public function testGetIdentity(): void
     {
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/testpath'],
-            [],
+        $request = $this->getMockRequest(
+            '/testpath',
             ['username' => 'robert', 'password' => 'robert']
         );
 

--- a/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
+++ b/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -16,13 +17,13 @@ namespace Phauthentic\Authentication\Test\TestCase\UrlChecker;
 
 use Phauthentic\Authentication\UrlChecker\DefaultUrlChecker;
 use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\ServerRequestFactory;
 
 /**
  * DefaultUrlCheckerTest
  */
 class DefaultUrlCheckerTest extends TestCase
 {
+    use RequestMockTrait;
 
     /**
      * testCheckFailure
@@ -33,10 +34,7 @@ class DefaultUrlCheckerTest extends TestCase
     {
         $checker = new DefaultUrlChecker();
 
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/users/does-not-match']
-        );
-
+        $request = $this->getMockRequest('/users/does-not-match');
         $result = $checker->check($request, '/users/login');
         $this->assertFalse($result);
     }
@@ -49,9 +47,8 @@ class DefaultUrlCheckerTest extends TestCase
     public function testCheck()
     {
         $checker = new DefaultUrlChecker();
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/users/login']
-        );
+
+        $request = $this->getMockRequest('/users/login');
         $result = $checker->check($request, '/users/login');
         $this->assertTrue($result);
     }
@@ -65,10 +62,8 @@ class DefaultUrlCheckerTest extends TestCase
     {
         $checker = new DefaultUrlChecker();
         $checker->checkFullUrl(true);
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/users/login', 'HTTP_HOST' => 'localhost']
-        );
 
+        $request = $this->getMockRequest('/users/login');
         $result = $checker->check($request, 'http://localhost/users/login');
         $this->assertTrue($result);
     }
@@ -82,10 +77,8 @@ class DefaultUrlCheckerTest extends TestCase
     {
         $checker = new DefaultUrlChecker();
         $checker->checkFullUrl(true);
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/users/does-not-match']
-        );
 
+        $request = $this->getMockRequest('/users/does-not-match');
         $result = $checker->check($request, 'http://localhost/users/login');
         $this->assertFalse($result);
     }

--- a/tests/TestCase/UrlChecker/RegexUrlCheckerTest.php
+++ b/tests/TestCase/UrlChecker/RegexUrlCheckerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -16,13 +17,13 @@ namespace Phauthentic\Authentication\Test\TestCase\UrlChecker;
 
 use Phauthentic\Authentication\UrlChecker\RegexUrlChecker;
 use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\ServerRequestFactory;
 
 /**
  * RegexUrlCheckerTest
  */
 class RegexUrlCheckerTest extends TestCase
 {
+    use RequestMockTrait;
 
     /**
      * testCheckFailure
@@ -33,10 +34,7 @@ class RegexUrlCheckerTest extends TestCase
     {
         $checker = new RegexUrlChecker();
 
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/users/does-not-match']
-        );
-
+        $request = $this->getMockRequest('/users/does-not-match');
         $result = $checker->check($request, '%^/[a-z]{2}/users/login/?$%');
         $this->assertFalse($result);
     }
@@ -49,10 +47,8 @@ class RegexUrlCheckerTest extends TestCase
     public function testCheck()
     {
         $checker = new RegexUrlChecker();
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/en/users/login']
-        );
 
+        $request = $this->getMockRequest('/en/users/login');
         $result = $checker->check($request, '%^/[a-z]{2}/users/login/?$%');
         $this->assertTrue($result);
     }
@@ -66,10 +62,8 @@ class RegexUrlCheckerTest extends TestCase
     {
         $checker = new RegexUrlChecker();
         $checker->checkFullUrl(true);
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/en/users/login']
-        );
 
+        $request = $this->getMockRequest('/en/users/login');
         $result = $checker->check($request, '%^http.*/[a-z]{2}/users/login/?$%');
         $this->assertTrue($result);
     }
@@ -83,10 +77,8 @@ class RegexUrlCheckerTest extends TestCase
     {
         $checker = new RegexUrlChecker();
         $checker->checkFullUrl(true);
-        $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/en/users/login']
-        );
 
+        $request = $this->getMockRequest('/en/users/login');
         $result = $checker->check($request, '%^https.*/[a-z]{2}/users/login/?$%');
         $this->assertFalse($result);
     }

--- a/tests/TestCase/UrlChecker/RequestMockTrait.php
+++ b/tests/TestCase/UrlChecker/RequestMockTrait.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+/**
+ * Copyright (c) Phauthentic (https://github.com/Phauthentic)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Phauthentic (https://github.com/Phauthentic)
+ * @link          https://github.com/Phauthentic
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Phauthentic\Authentication\Test\TestCase\UrlChecker;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * RequestMockTrait
+ */
+trait RequestMockTrait
+{
+    /**
+     * Gets a mocked request that contains the URI
+     *
+     * @param $uriString URI String
+     * @return mixed
+     */
+    public function getMockRequest($uriString)
+    {
+        $request = $this->getMockBuilder(ServerRequestInterface::class)
+            ->getMock();
+
+        $uri = $this->getMockBuilder(UriInterface::class)
+            ->getMock();
+
+        $uri->expects($this->any())
+            ->method('getPath')
+            ->willReturn($uriString);
+
+        $uri->expects($this->any())
+            ->method('__toString')
+            ->willReturn('http://localhost' . $uriString);
+
+        $request->expects($this->any())
+            ->method('getUri')
+            ->willReturn($uri);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
Zend is only used in the tests but I would like to get rid of it there as well and use traits instead.